### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/cerbere-go-test-test.el
+++ b/test/cerbere-go-test-test.el
@@ -22,8 +22,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
-
 (require 'cerbere)
 (require 'cerbere-gotest)
 

--- a/test/cerbere-phpunit-test.el
+++ b/test/cerbere-phpunit-test.el
@@ -20,8 +20,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
-
 (require 'cerbere)
 (require 'cerbere-phpunit)
 

--- a/test/cerbere-test.el
+++ b/test/cerbere-test.el
@@ -20,8 +20,6 @@
 ;;; Code:
 
 
-(require 'test-helper)
-
 (require 'cerbere)
 
 

--- a/test/cerbere-tox-test.el
+++ b/test/cerbere-tox-test.el
@@ -19,8 +19,6 @@
 
 ;;; Code:
 
-(require 'test-helper)
-
 (require 'cerbere)
 
 ;; cerbere-tox mode

--- a/test/cerbere-version-test.el
+++ b/test/cerbere-version-test.el
@@ -21,8 +21,6 @@
 
 ;;; Code:
 
-(require 'test-helper)
-
 (ert-deftest cerbere-mode-library-version ()
   :expected-result (if (executable-find "cask") :passed :failed)
   ;;  The default directory must end with a slash

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -38,7 +38,4 @@
 (message "Load cerbere : %s" cerbere-source-dir)
 (load (s-concat cerbere-source-dir "/cerbere.elc"))
 
-
-
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
**Note that unlike for most of the other pull requests I just opened I
was not able to run the tests for this package.  I get an error about
marmalade not being available when running `cask install`.**

The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Also see https://github.com/rejeep/ert-runner.el/issues/38.